### PR TITLE
Workspace creation modal

### DIFF
--- a/apps/backend/src/app/modules/workspaces/create-workspace.dto.ts
+++ b/apps/backend/src/app/modules/workspaces/create-workspace.dto.ts
@@ -1,0 +1,13 @@
+import { WorkspaceVisibility } from '@dializer/types';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateWorkspaceDTO {
+  @ApiPropertyOptional()
+  title?: string;
+
+  @ApiPropertyOptional({ enum: WorkspaceVisibility })
+  visibility?: WorkspaceVisibility;
+
+  @ApiPropertyOptional()
+  description?: string;
+}

--- a/apps/backend/src/app/modules/workspaces/workspaces.controller.ts
+++ b/apps/backend/src/app/modules/workspaces/workspaces.controller.ts
@@ -17,6 +17,7 @@ import { capitalize } from '../../utils';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { UpdateWorkspaceNodesDTO } from './update-nodes.dto';
 import { WorkspacesService } from './workspaces.service';
+import { CreateWorkspaceDTO } from './create-workspace.dto';
 
 @Controller(ApiEndpoints.WORKSPACES)
 @ApiTags(capitalize(ApiEndpoints.WORKSPACES))
@@ -40,9 +41,9 @@ export class WorkspacesController {
   @ApiOperation({ summary: 'Create new workspace' })
   @Post()
   @UseGuards(JwtAuthGuard)
-  async create(@Req() req: Request) {
+  async create(@Body() payload: CreateWorkspaceDTO, @Req() req: Request) {
     const user = req.user as { id: string; email: string };
-    return await this.workspacesService.createNewWorkspace(user.id);
+    return await this.workspacesService.createNewWorkspace(user.id, payload);
   }
 
   @ApiOperation({ summary: "Update a workspace's metadata (title, etc.)" })

--- a/apps/backend/src/app/modules/workspaces/workspaces.service.ts
+++ b/apps/backend/src/app/modules/workspaces/workspaces.service.ts
@@ -3,8 +3,9 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { ILike, Repository } from 'typeorm';
 import { Workspace } from './workspace.entity';
 import { Node } from '../nodes/node.entity';
-import { NodeTypes } from '@dializer/types';
+import { NodeTypes, WorkspaceVisibility } from '@dializer/types';
 import { v4 as uuidv4 } from 'uuid';
+import { CreateWorkspaceDTO } from './create-workspace.dto';
 
 @Injectable()
 export class WorkspacesService {
@@ -45,9 +46,11 @@ export class WorkspacesService {
     return nodes;
   }
 
-  async createNewWorkspace(ownerId: string) {
+  async createNewWorkspace(ownerId: string, payload?: CreateWorkspaceDTO) {
     const workspace = this.workspaceRepo.create({
-      title: 'New workspace',
+      title: payload?.title ?? 'New workspace',
+      visibility: payload?.visibility ?? WorkspaceVisibility.PRIVATE,
+      description: payload?.description,
       owner: { id: ownerId },
       nodes: [
         {

--- a/apps/frontend/services/workspace.ts
+++ b/apps/frontend/services/workspace.ts
@@ -53,12 +53,21 @@ export class WorkspaceService extends ApiService {
     return await response.json();
   }
 
-  async create(): Promise<WorkspaceEntity> {
+  /**
+   * Create new workspace. Workspace data is optional, if no data is given,
+   * new workspace will be created using the default settings:
+   * Title: "New Workspace"
+   * Visibility: Private
+   * Description: None
+   */
+  async create(args?: Partial<WorkspaceEntity>): Promise<WorkspaceEntity> {
     const response = await fetch(`${this.apiUrl}/workspaces`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${this.accessToken}`,
+        'Content-Type': 'application/json',
       },
+      body: JSON.stringify(args),
     });
 
     const jsonResponse = await response.json();


### PR DESCRIPTION
When creating new workspace, instead of initiating the workspace with default data and then immediately redirecting the user to the workspace page, now user needs to specify the title, description, and visiblity of the workspace.

Resolves #14 